### PR TITLE
KOGITO-310: [gwt-jsonix-marshallers] Replace use of Object with generic 'D'

### DIFF
--- a/gwt-jsonix-schema-compiler/src/main/java/gwt/jsonix/marshallers/xjc/plugin/builders/JsUtilsBuilder.java
+++ b/gwt-jsonix-schema-compiler/src/main/java/gwt/jsonix/marshallers/xjc/plugin/builders/JsUtilsBuilder.java
@@ -37,6 +37,7 @@ import com.sun.codemodel.JForLoop;
 import com.sun.codemodel.JInvocation;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
+import com.sun.codemodel.JTypeVar;
 import com.sun.codemodel.JVar;
 import jsinterop.base.Js;
 import jsinterop.base.JsArrayLike;
@@ -155,7 +156,7 @@ public class JsUtilsBuilder {
             "     * Helper method to create a new empty JavaScript object.\n" +
             "     * @return\n" +
             "     */\n" +
-            "    private static native Object getJsObject() /*-{\n" +
+            "    private static native <D> D getJsObject() /*-{\n" +
             "        return {};\n" +
             "    }-*/;\n";
 
@@ -408,9 +409,11 @@ public class JsUtilsBuilder {
         log(LogLevelSetting.DEBUG, "Add java 'fromAttributesMapMethod' method...");
         JClass narrowedMap = getQNameStringNarrowedMapClass(jCodeModel);
         final JMethod toReturn = getJMethod(jsUtils, jCodeModel.ref(Object.class), "fromAttributesMap");
+        final JTypeVar type = toReturn.generify("D");
+        toReturn.type(type);
         toReturn.param(JMod.FINAL, narrowedMap, "original");
         final JBlock block = toReturn.body();
-        final JVar mapToReturn = block.decl(JMod.FINAL, jCodeModel.ref(Object.class), "toReturn", JExpr.invoke("getJsObject"));
+        final JVar mapToReturn = block.decl(JMod.FINAL, type, "toReturn", JExpr.invoke("getJsObject"));
         block.directStatement(FROM_ATTRIBUTES_MAP_METHOD_BODY);
         block._return(mapToReturn);
         final JDocComment javadoc = toReturn.javadoc();


### PR DESCRIPTION
@gitgabrio Further to your [comment](https://github.com/gitgabrio/gwt-jsonix-marshallers/pull/14#issuecomment-533198590) I've changed to use `D` instead of `Object`.

I confirm DMN still works happily with the change.